### PR TITLE
Decode stdout bytes to UTF-16 instead of UTF-8

### DIFF
--- a/find_stable.py
+++ b/find_stable.py
@@ -122,11 +122,9 @@ class Finder:
             return None
         
 
-        # Convert stdout to UTF-8 string from bytes.
+        # Convert stdout to UTF-16 string from bytes.
         # TODO: test Windows compatibility?
-        # Greek letters not supported for commented out part!!
-        '''
-        stdout = proc.stdout.decode("utf-8")
+        stdout = proc.stdout.decode("utf-16")
         expr = r"\[ffmpeg\] Destination: (.*\.mp3).*"
         match = re.search(expr, stdout)
 
@@ -134,15 +132,10 @@ class Finder:
             return None
         
         song_fpath = match.groups()[0]
-        
-        
-        print(f"\n\n{stdout}\n===\n{expr}\n===\n{match}\n===\n{match.groups()}\n\n")
-        exit()
         return song_fpath
-        '''
         
         ### This does support greek letters even though it may not be the best way to do it.
-        return os.path.abspath(os.path.join("downloaded_mp3s", os.listdir("downloaded_mp3s")[0]))
+        #return os.path.abspath(os.path.join("downloaded_mp3s", os.listdir("downloaded_mp3s")[0]))
     
     
     def get_song_mp3_speedmode(self, id):


### PR DESCRIPTION
@Ben-0-mad I changed the bytestring decode to UTF-16 instead of UTF-8. Can you check whether Greek characters are still an issue on your end with this change?

If it still doesn't work on your end, can you provide an example input and the resulting error/output? I tried Greek characters with UTF-8 and it worked fine for me, so I'm curious to find out what's causing the problem.

Hoping to get this resolved ASAP because os.listdir()[0] makes it impossible to reliably process multiple videos simultaneously. Also, the order of the files given by os.listdir() is arbitrary and should not be relied upon in the event that more than 1 file exists in the directory at a time.